### PR TITLE
Add a self-referential note

### DIFF
--- a/template.md
+++ b/template.md
@@ -39,3 +39,5 @@ Quick description of frontend changes. For pull requests that contain multiple c
 - [ ] 2nd Review
 
 **Delete branch when the PR is closed:** YES/NO (PICK ONE)
+
+**NOTE: This PR built using the [The snagajob PR Template](https://github.com/Snagajob/pr-template)**


### PR DESCRIPTION
This allows people reviewing PRs from this template to learn how to start using it for their own PRs.  That will help usage spread through engineering right now, and help new employees find it quickly.
